### PR TITLE
Fix wrong javadoc url of TestSubscriber

### DIFF
--- a/src/test/java/io/pivotal/literx/Part01CreateFlux.java
+++ b/src/test/java/io/pivotal/literx/Part01CreateFlux.java
@@ -9,7 +9,7 @@ import reactor.test.TestSubscriber;
  *
  * @author Sebastien Deleuze
  * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/publisher/Flux.html">Flux Javadoc</a>
- * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/test/TestSubscriber.html">TestSubscriber Javadoc</a>
+ * @see <a href="http://projectreactor.io/core/docs/api/reactor/test/TestSubscriber.html">TestSubscriber Javadoc</a>
  */
 public class Part01CreateFlux {
 


### PR DESCRIPTION
TestSubscriber javadoc link is wrong.
